### PR TITLE
Load random barcode by default

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,7 @@ class App extends Component {
   async componentDidMount() {
     try {
       this.setState({ total: await fetchTotal() });
+      this.handleReal();
     } catch (err) {
       console.error(err);
     }

--- a/src/App.js
+++ b/src/App.js
@@ -19,7 +19,6 @@ class App extends Component {
 
   async componentDidMount() {
     try {
-      this.setState({ total: await fetchTotal() });
       this.handleReal();
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
When visiting https://www.randomvinbarcode.com/, most users would prefer to see a barcode immediately. This PR accomplishes that by calling `handleReal()` once when the app first mounts.